### PR TITLE
v4.1.1 Added syslog support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,9 @@ MONICA_LABELS_EXCLUDE=
 DATABASE_FILE=data/syncState.db
 GOOGLE_TOKEN_FILE=data/token.pickle
 GOOGLE_CREDENTIALS_FILE=data/credentials.json
+
+# Send messages to a syslog server
+# An alternative to providing target host and port is providing only a target address, for example "/dev/log".
+# In this case, a Unix domain socket is used to send the message to the syslog.
+SYSLOG_TARGET=
+SYSLOG_PORT=

--- a/.github/actions/cleanup-environment/action.yml
+++ b/.github/actions/cleanup-environment/action.yml
@@ -25,6 +25,7 @@ runs:
 
       - name: Upload Google token to repo secrets
         run: python test/UpdateToken.py
+        if: always()
         env:
           REPO_TOKEN: ${{ inputs.REPO_TOKEN }}
         shell: bash

--- a/.github/workflows/docker-cd-release.yml
+++ b/.github/workflows/docker-cd-release.yml
@@ -20,7 +20,7 @@ jobs:
       - 
         name: "Create tags for Docker image"
         id: docker_meta
-        uses: docker/metadata-action@v3.6.1
+        uses: docker/metadata-action@v3.6.2
         with:
           tag-latest: true
           images: antonplagemann/google-monica-sync

--- a/GMSync.py
+++ b/GMSync.py
@@ -16,7 +16,7 @@ from helpers.GoogleHelper import Google
 from helpers.MonicaHelper import Monica
 from helpers.SyncHelper import Sync
 
-VERSION = "v4.1.0"
+VERSION = "v4.1.1"
 LOG_FOLDER = "logs"
 LOG_FILENAME = "sync.log"
 DEFAULT_CONFIG_FILEPATH = join("helpers", ".env.default")

--- a/Setup.md
+++ b/Setup.md
@@ -51,6 +51,8 @@ To configure the OAuth consent screen:
     > Hint: If you get a `403 forbidden` during consent later, you may have entered the wrong email here.
 12. Click `Save and Continue`. The "OAuth consent screen" appears.
 13. Click `Back to Dashboard`.
+14. Back at the "OAuth consent screen" screen, click `PUBLISH APP` and then `CONFIRM`.
+    > This step is necessary because when in "Testing"-status, Google limits the token lifetime to seven days. You don't need to complete the app verification process.
 
 ### Create an OAuth client ID credential
 

--- a/helpers/.env.default
+++ b/helpers/.env.default
@@ -31,3 +31,9 @@ MONICA_LABELS_EXCLUDE=
 DATABASE_FILE=data/syncState.db
 GOOGLE_TOKEN_FILE=data/token.pickle
 GOOGLE_CREDENTIALS_FILE=data/credentials.json
+
+# Send messages to a syslog server
+# An alternative to providing target host and port is providing only a target address, for example "/dev/log".
+# In this case, a Unix domain socket is used to send the message to the syslog.
+SYSLOG_TARGET=
+SYSLOG_PORT=

--- a/helpers/ConfigHelper.py
+++ b/helpers/ConfigHelper.py
@@ -29,6 +29,8 @@ class Config:
             self.DATABASE_FILE = abspath(self._values["DATABASE_FILE"])
             self.GOOGLE_TOKEN_FILE = abspath(self._values["GOOGLE_TOKEN_FILE"])
             self.GOOGLE_CREDENTIALS_FILE = abspath(self._values["GOOGLE_CREDENTIALS_FILE"])
+            self.SYSLOG_TARGET = self._values["SYSLOG_TARGET"]
+            self.SYSLOG_PORT = self._values["SYSLOG_PORT"]
         except Exception as e:
             raise ConfigError("Error parsing config, check syntax and required args!") from e
 

--- a/helpers/GoogleHelper.py
+++ b/helpers/GoogleHelper.py
@@ -64,7 +64,7 @@ class Google:
                     creds_pickled = base64_token.read()
                 creds = pickle.loads(codecs.decode(creds_pickled.encode(), "base64"))
             else:
-                raise ConfigError("Google token file not found!")
+                self.log.warning("Google token file not found!")
         except UnicodeDecodeError:
             # Maybe old pickling file, try to update
             with open(self.token_file, "rb") as binary_token:

--- a/test/SetupToken.py
+++ b/test/SetupToken.py
@@ -10,14 +10,15 @@ from urllib.parse import unquote
 
 import requests
 from bs4 import BeautifulSoup  # type: ignore
-from dotenv.main import load_dotenv, set_key  # type: ignore
+from dotenv.main import dotenv_values, set_key  # type: ignore
 from requests import ConnectionError, ConnectTimeout, ReadTimeout
 
 LOG_FOLDER = "logs"
 LOG_FILENAME = "setup.log"
 try:
-    load_dotenv()
-    PROTOCOL, HOST, PORT = re.findall(r"(https?)://(.+?):(\d+)/api/?", os.getenv("BASE_URL", ""))[0]
+    config = dotenv_values(".env")
+    result = re.findall(r"(https?)://(.+?):(\d+)/api/?", str(config.get("BASE_URL", "")))
+    PROTOCOL, HOST, PORT = result[0]
 except IndexError:
     PROTOCOL, HOST, PORT = "http", "localhost", 8080
 ENV_FILE = ".env"


### PR DESCRIPTION
New features:
- Added support for sending all log messages to a syslog server
    See `conf.example` on how to set the syslog target server or file.

Bugfixes:
- Fixed wrong "no token"-exception that made it impossible to complete the authorization flow to get a new Google token
- Updated readme to avoid Google token expiration after 7 days
