### PR TITLE
Migrate away from the OAuth out-of-band (OOB) flow https://developers…

### DIFF
--- a/helpers/GoogleHelper.py
+++ b/helpers/GoogleHelper.py
@@ -82,7 +82,7 @@ class Google:
                     self.credentials_file,
                     scopes=["https://www.googleapis.com/auth/contacts"],
                 )
-                creds = flow.run_console(prompt="consent", authorization_prompt_message=prompt)
+                creds = flow.run_local_server(port=0)
             else:
                 self.log.error("The 'token.pickle' file was not found or invalid!")
                 self.log.info(


### PR DESCRIPTION
Google is changing OAuth interaction by using more secure OAuth flow starting Oct 2022. Due to this, the current OAuth flow doesn't work and this repo is unusable.

This change enables OAuth credential/token connections again.